### PR TITLE
Fix example android

### DIFF
--- a/Sample/Droid/Renderer/CropViewRenderer.cs
+++ b/Sample/Droid/Renderer/CropViewRenderer.cs
@@ -23,7 +23,8 @@ namespace Xam.Plugins.ImageCropper.Sample.Droid
                 Bitmap bitmp = BitmapFactory.DecodeByteArray(page.Image, 0, page.Image.Length);
                 cropImageView.SetImageBitmap(bitmp);
 
-                var stackLayout = new StackLayout { Children = { cropImageView } };
+                var scrollView = new ScrollView { Content = cropImageView.ToView() };
+                var stackLayout = new StackLayout { Children = { scrollView } };
 
                 var rotateButton = new Button { Text = "Rotate" };
 


### PR DESCRIPTION
when you take a photo for example, the image take all the screen and you don't see the buttons Rotate and Finished